### PR TITLE
Bugfix for inaccessible interfaces

### DIFF
--- a/src/SourceInject/Generator.cs
+++ b/src/SourceInject/Generator.cs
@@ -72,6 +72,12 @@ internal class InjectTransientAttribute : System.Attribute
             }
             foreach (var interf in ((ITypeSymbol)symbol).AllInterfaces)
             {
+                if (interf.DeclaredAccessibility != Accessibility.Public &&
+                    !SymbolEqualityComparer.Default.Equals(interf.ContainingModule, context.Compilation.SourceModule))
+                {
+                    continue;
+                }
+
                 switch (lifetime)
                 {
                     case Lifetime.Singleton:

--- a/test/ConsoleApp/ExampleService.cs
+++ b/test/ConsoleApp/ExampleService.cs
@@ -1,9 +1,10 @@
+using Lib;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace ConsoleApp;
 
 [Inject]
-public class ExampleService
+public class ExampleService : LibBaseService, IExampleService
 {
     private readonly AnotherService anotherService;
 
@@ -19,7 +20,7 @@ public interface IAnotherService
 }
 
 [Inject(ServiceLifetime.Singleton)]
-public class AnotherService : IAnotherService
+public class AnotherService : LibBaseService, IAnotherService
 {
     public string Value => "Hello World!";
 }

--- a/test/ConsoleApp/IExampleService.cs
+++ b/test/ConsoleApp/IExampleService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConsoleApp
+{
+    internal interface IExampleService
+    {
+    }
+}

--- a/test/Lib/ILibInternalInterface.cs
+++ b/test/Lib/ILibInternalInterface.cs
@@ -1,0 +1,6 @@
+namespace Lib
+{
+    internal interface ILibInternalInterface
+    {
+    }
+}

--- a/test/Lib/ILibPublicInterface.cs
+++ b/test/Lib/ILibPublicInterface.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lib
+{
+    public interface ILibPublicInterface
+    {
+    }
+}

--- a/test/Lib/LibBaseService.cs
+++ b/test/Lib/LibBaseService.cs
@@ -1,0 +1,6 @@
+namespace Lib
+{
+    public class LibBaseService : ILibInternalInterface, ILibPublicInterface
+    {
+    }
+}


### PR DESCRIPTION
Only generate the interface when it is accessible from the module (so it is public or it resides in the same module)